### PR TITLE
Revert updates by dependabot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ test = [
   "pytest<8",
   "pytest-cov<4",
   "pytest-mock<4",
-  "pyfakefs<6",
+  "pyfakefs<5",
   "smtpdfix<1",
   "surrogate<1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
   "pytest<8",
-  "pytest-cov<5",
+  "pytest-cov<4",
   "pytest-mock<4",
   "pyfakefs<6",
   "smtpdfix<1",


### PR DESCRIPTION
Test coverage on CI dropped from 69% to 47%. This patch investigates if this has been caused by two updates recently submitted by @dependabot, namely 7c6c7e0f and f4734f06ba.